### PR TITLE
feat: support detection of file type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dice-mist",
-	"version": "0.0.8",
+	"version": "0.1.0",
 	"description": "A wrapper for the evaporate library allowing use in a web worker.",
 	"keywords": [
 		"S3 Upload",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dice-mist",
-	"version": "0.0.7",
+	"version": "0.0.8",
 	"description": "A wrapper for the evaporate library allowing use in a web worker.",
 	"keywords": [
 		"S3 Upload",

--- a/src/Mist.ts
+++ b/src/Mist.ts
@@ -13,7 +13,6 @@ export default class Mist extends MistBase {
 					name,
 					file,
 					progress: (percentage) => this.onProgress(percentage, file.id),
-					/* TODO check if mistThreaded needs this same adjustment */
 					contentType: config.sendFileContentType ? file.type : undefined, // if not specified or affected by external factors, the content-type of the file in the bucket will be `application/octet-stream`. The `sendFileContentType` config keeps this backwards compatible.
 				};
 				const cancel = () => evaporate.cancel(`${data.bucketName}/${data.path}`);

--- a/src/Mist.ts
+++ b/src/Mist.ts
@@ -13,6 +13,8 @@ export default class Mist extends MistBase {
 					name,
 					file,
 					progress: (percentage) => this.onProgress(percentage, file.id),
+					/* TODO check if mistThreaded needs this same adjustment */
+					contentType: config.sendFileContentType ? file.type : undefined, // if not specified or affected by external factors, the content-type of the file in the bucket will be `application/octet-stream`. The `sendFileContentType` config keeps this backwards compatible.
 				};
 				const cancel = () => evaporate.cancel(`${data.bucketName}/${data.path}`);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,5 +10,6 @@ export enum WorkerMessages {
 
 export interface IConfig {
 	worker?: boolean;
+	sendFileContentType?: boolean;
 	[key: string]: any;
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -46,7 +46,8 @@ class Worker {
 				name,
 				file,
 				bucket,
-				progress: progress => postMessage({ type: WorkerMessages.PROGRESS, progress, id })
+				progress: progress => postMessage({ type: WorkerMessages.PROGRESS, progress, id }),
+				contentType: config.sendFileContentType ? file.type : undefined, // if not specified or affected by external factors, the content-type of the file in the bucket will be `application/octet-stream`. The `sendFileContentType` config keeps this backwards compatible.
 			};
 
 			postMessage({type: WorkerMessages.START, id, cancelId});


### PR DESCRIPTION
<!-- REMOVE ALL NON-APPLICABLE SECTIONS -->

## Purpose

When enabled, detects and sends the file's mime-type as `contentType` to S3.


## Jira ticket

[REDACTED]



[REDACTED]

[REDACTED]